### PR TITLE
Update readme with app-specific notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OOD Remote Desktop - Apptainer
+# OOD Remote Desktop - ROS / Gazebo / Matlab
 
 This repo contains a working configuration to run a remote desktop in an apptainer configuration in Open OnDemand in the HUIT OOD environment. It requires a [spack](https://spack.io/) environment to use [apptainer](https://apptainer.org/) commands, and also requires a built container that exists in a location accessible to compute nodes. In this case that's a shared EFS volume.
 
@@ -12,4 +12,8 @@ The spack environment is articulated in `spack-environment/apptainer/spack.yml`.
 
 ## Apptainer container
 
-The definition for the apptainer container is at `build/xfce.def`. It can be invoked after the apptainer module is loaded with `apptainer build /shared/apptainerImages/xfce.sif ./build/xfce.def` from the root of this repo. This is a native apptainer image build based on an Ubuntu docker image.
+The desktop image, built in build/rosgazebo.def, will set up a desktop image containing [ROS Noetic](https://www.ros.org/), [Gazebo](https://gazebosim.org/home), [Matlab](https://matlab.com), and [VS Codium](https://vscodium.com/). The Matlab installation requires some additional setup in advance. There must be a Matlab installation directory at /shared/MATLAB, and it must contain an appropriate `network.lic` file and `installer_input.txt` file. These are used in the installation process, but are not included in this repository.
+
+The Matlab installation directory must be downloaded from Matlab, following the instructions to [Download Products without Installing](https://www.mathworks.com/help/install/ug/download-without-installing.html). The installation and configuration files are stored in an S3 bucket called `ood-software` for easier access.
+
+The image can be built after the apptainer module is loaded with `apptainer build /shared/apptainerImages/rosgazebo.sif ./build/rosgazebo.def` from the root of this repo. This is a native apptainer image build, primarily using shell scripting in the `%post` section. See the build definition itself for full details on the image.


### PR DESCRIPTION
This PR updates the README file to include information on the specific setup of the apps in the container definition. The Matlab setup is particularly involved, requiring downloading the latest version of the software from Matlab itself.

As part of this PR, I created an S3 bucket called ood-software that we can use for this software, and anything else that comes up with similar requirements. It's in the acadcompute-dev account, so when we deploy to prod we may need to update the permissions. The bucket includes the installation files, as well as a script to prepare them for use in the shared directory.