### PR TITLE
Add library, switch to fork of universal robots

### DIFF
--- a/build/rosgazebo.def
+++ b/build/rosgazebo.def
@@ -56,7 +56,8 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y \
     ros-${ROS_DISTRO}-ur-gazebo \
     ros-${ROS_DISTRO}-ur5-moveit-config \
     ros-${ROS_DISTRO}-ros-control \
-    ros-${ROS_DISTRO}-ros-controllers && \
+    ros-${ROS_DISTRO}-ros-controllers \
+    ros-${ROS_DISTRO}-velocity-controllers && \
 rm -rf /var/lib/apt/lists/*
 echo "$(date -Iminutes) END - ROS software install"
 
@@ -95,7 +96,7 @@ echo "$(date -Iminutes) END - initialize rosdep"
 echo "$(date -Iminutes) START - Install Universal Robots"
 mkdir -p /opt/catkin_ws/src && \
     cd /opt/catkin_ws/src && \
-    git clone --branch ${ROS_DISTRO}-devel https://github.com/ros-industrial/universal_robot.git
+    git clone --branch ${ROS_DISTRO}-devel https://github.com/Aryan-Naveen/universal_robot.git
 cd /opt/catkin_ws && rosdep update && \
     apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive rosdep install --rosdistro ${ROS_DISTRO} --ignore-src --from-paths src --default-yes  && \


### PR DESCRIPTION
We received a request to make the following changes to the OOD ROS/Gazebo desktop image:

> (1) In the catkin_ws replace universal_robot with my forked version from https://github.com/Aryan-Naveen/universal_robot and rebuild the workspace.
> (2) Run sudo apt-get install ros-noetic-velocity-controllers 

This PR implements those requested changes. When it has been tested in the stage environment, it will be ready for review.